### PR TITLE
Make CSS property values priority numeric

### DIFF
--- a/src/producer/produce-basic-style.spec.ts
+++ b/src/producer/produce-basic-style.spec.ts
@@ -5,6 +5,7 @@ import { NamespaceDef } from 'namespace-aliaser';
 import { StypProperties, stypRoot, StypRule } from '../rule';
 import { stypSelector } from '../selector';
 import { cssStyle, cssStyles, removeStyleElements, scheduleNow, stylesheets } from '../spec';
+import { StypLength } from '../value/unit';
 import { produceBasicStyle } from './produce-basic-style';
 import { StypRender } from './render';
 import { StyleProducer } from './style-producer';
@@ -325,6 +326,24 @@ describe('produceBasicStyle', () => {
   });
   it('renders important properties', () => {
     root.rules.add({ c: 'custom' }, { fontSize: '12px !important' });
+    produceBasicStyle(root.rules, { schedule: scheduleNow });
+
+    const style = cssStyle('.custom');
+
+    expect(style.getPropertyValue('font-size')).toBe('12px');
+    expect(style.getPropertyPriority('font-size')).toBe('important');
+  });
+  it('renders prioritized properties', () => {
+    root.rules.add({ c: 'custom' }, { fontSize: StypLength.of(12, 'px').prioritize(0.5) });
+    produceBasicStyle(root.rules, { schedule: scheduleNow });
+
+    const style = cssStyle('.custom');
+
+    expect(style.getPropertyValue('font-size')).toBe('12px');
+    expect(style.getPropertyPriority('font-size')).toBe('');
+  });
+  it('renders prioritized important properties', () => {
+    root.rules.add({ c: 'custom' }, { fontSize: StypLength.of(12, 'px').prioritize(1.5) });
     produceBasicStyle(root.rules, { schedule: scheduleNow });
 
     const style = cssStyle('.custom');

--- a/src/producer/properties.render.ts
+++ b/src/producer/properties.render.ts
@@ -22,7 +22,7 @@ export function stypRenderProperties(producer: StyleProducer, properties: StypPr
 
         const [value, priority] = stypSplitPriority(v);
 
-        style.setProperty(hyphenateStyleName(k), `${value}`, priority);
+        style.setProperty(hyphenateStyleName(k), `${value}`, priority >= 1 ? 'important' : undefined);
       });
 
   producer.render(properties, { target: cssRule });

--- a/src/producer/properties.render.ts
+++ b/src/producer/properties.render.ts
@@ -1,7 +1,7 @@
 import { filterIt, itsEach, ObjectEntry, overEntries } from 'a-iterable';
 import hyphenateStyleName from 'hyphenate-style-name';
 import { StypProperties } from '../rule';
-import { stypSplitPriority } from '../value';
+import { StypPriority, stypSplitPriority } from '../value';
 import { StyleProducer } from './style-producer';
 
 /**
@@ -22,7 +22,10 @@ export function stypRenderProperties(producer: StyleProducer, properties: StypPr
 
         const [value, priority] = stypSplitPriority(v);
 
-        style.setProperty(hyphenateStyleName(k), `${value}`, priority >= 1 ? 'important' : undefined);
+        style.setProperty(
+            hyphenateStyleName(k),
+            `${value}`,
+            priority >= StypPriority.Important ? 'important' : undefined);
       });
 
   producer.render(properties, { target: cssRule });

--- a/src/rule/properties.impl.ts
+++ b/src/rule/properties.impl.ts
@@ -162,19 +162,19 @@ function addValue(
     properties: StypProperties.Mutable,
     key: keyof StypProperties,
     value: StypValue): StypProperties.Mutable {
-  if (!isImportantValue(properties[key]) || isImportantValue(value)) {
+  if (priorityOf(properties[key]) <= priorityOf(value)) {
     delete properties[key];
     properties[key] = value;
   }
   return properties;
 }
 
-function isImportantValue(value: StypValue) {
+function priorityOf(value: StypValue): number {
   switch (typeof value) {
     case 'string':
-      return value.endsWith(IMPORTANT_CSS_SUFFIX);
+      return value.endsWith(IMPORTANT_CSS_SUFFIX) ? 1 : 0;
     case 'object':
-      return value.priority === 'important';
+      return value.priority;
   }
-  return false;
+  return 0;
 }

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -2,3 +2,4 @@ export * from './colors';
 export * from './properties';
 export * from './schedulers';
 export * from './stylesheets';
+export * from './values';

--- a/src/spec/values.ts
+++ b/src/spec/values.ts
@@ -1,0 +1,8 @@
+import { stypSplitPriority, StypValue } from '../value';
+
+export function textAndPriority(value: StypValue): [string, number] {
+
+  const [v, p] = stypSplitPriority(value);
+
+  return [`${v}`, p];
+}

--- a/src/value/color/color.spec.ts
+++ b/src/value/color/color.spec.ts
@@ -14,6 +14,7 @@ import {
   rgbRed,
   rgbWhite
 } from '../../spec';
+import { StypPriority } from '../priority';
 import { StypLength } from '../unit';
 import { StypColor, StypHSL, StypRGB } from './color';
 
@@ -187,7 +188,7 @@ describe('StypHSL', () => {
       const important = value.important();
 
       expect(important).not.toBe(value);
-      expect(important.priority).toBe(1);
+      expect(important.priority).toBe(StypPriority.Important);
       expect(important).toMatchObject(coords);
       expect(important).toEqual(value.important());
     });

--- a/src/value/color/color.spec.ts
+++ b/src/value/color/color.spec.ts
@@ -56,7 +56,7 @@ describe('StypRGB', () => {
       const important = value.important();
 
       expect(important).not.toBe(value);
-      expect(important.priority).toBe('important');
+      expect(important.priority).toBe(1);
       expect(important).toMatchObject(coords);
       expect(important).toEqual(value.important());
     });
@@ -187,7 +187,7 @@ describe('StypHSL', () => {
       const important = value.important();
 
       expect(important).not.toBe(value);
-      expect(important.priority).toBe('important');
+      expect(important.priority).toBe(1);
       expect(important).toMatchObject(coords);
       expect(important).toEqual(value.important());
     });

--- a/src/value/color/color.ts
+++ b/src/value/color/color.ts
@@ -151,7 +151,7 @@ export class StypRGB extends StypColorStruct<StypRGB, StypRGB.Coords> implements
         && other.priority === this.priority;
   }
 
-  prioritize(priority: 'important' | undefined): StypRGB {
+  prioritize(priority: number): StypRGB {
     return this.priority === priority ? this : new StypRGB(this, { priority });
   }
 
@@ -295,7 +295,7 @@ export class StypHSL extends StypColorStruct<StypHSL, StypHSL.Coords> implements
         && other.priority === this.priority;
   }
 
-  prioritize(priority: 'important' | undefined): StypHSL {
+  prioritize(priority: number): StypHSL {
     return this.priority === priority ? this : new StypHSL(this, { priority });
   }
 

--- a/src/value/index.ts
+++ b/src/value/index.ts
@@ -1,6 +1,7 @@
 export * from './color';
 export * from './numeric';
 export * from './mapper';
+export * from './priority';
 export * from './unit';
 export * from './url';
 export * from './value';

--- a/src/value/numeric/numeric.impl.ts
+++ b/src/value/numeric/numeric.impl.ts
@@ -68,7 +68,7 @@ export class StypDimension<Unit extends string>
         && this.priority === other.priority;
   }
 
-  prioritize(priority: 'important' | undefined): StypDimension<Unit> {
+  prioritize(priority: number): StypDimension<Unit> {
     return this.priority === priority
         ? this
         : new StypDimension(this.val, this.unit, { dim: this.dim, priority });
@@ -128,7 +128,7 @@ function stypDimension<Unit extends string>(
     val: number,
     unit: Unit,
     opts: StypDimension_.Opts<Unit>): StypDimension_<Unit> | StypZero<Unit> {
-  return val ? new StypDimension<Unit>(val, unit, opts) : opts.dim.zero.prioritize(opts && opts.priority);
+  return val ? new StypDimension<Unit>(val, unit, opts) : opts.dim.zero.prioritize(opts.priority || 0);
 }
 
 /**
@@ -193,7 +193,7 @@ export abstract class StypCalcBase<
 
   abstract negate(): StypNumeric<Unit>;
 
-  abstract prioritize(priority: 'important' | undefined): Self;
+  abstract prioritize(priority: number): Self;
 
   abstract toFormula(): string;
 
@@ -218,7 +218,7 @@ export class StypAddSub<Unit extends string>
     super(left, op, right.usual(), opts);
   }
 
-  prioritize(priority: 'important' | undefined): StypAddSub<Unit> {
+  prioritize(priority: number): StypAddSub<Unit> {
     return this.priority === priority
         ? this
         : new StypAddSub(this.left, this.op, this.right, { dim: this.dim, priority });
@@ -280,7 +280,7 @@ export class StypMulDiv<Unit extends string>
     extends StypCalcBase<StypMulDiv<Unit>, '*' | '/', number, Unit>
     implements StypMulDiv_<Unit> {
 
-  prioritize(priority: 'important' | undefined): StypMulDiv<Unit> {
+  prioritize(priority: number): StypMulDiv<Unit> {
     return this.priority === priority
         ? this
         : new StypMulDiv(this.left, this.op, this.right, { dim: this.dim, priority });

--- a/src/value/numeric/numeric.impl.ts
+++ b/src/value/numeric/numeric.impl.ts
@@ -1,3 +1,4 @@
+import { StypPriority } from '../priority';
 import {
   StypAddSub as StypAddSub_,
   StypDimension as StypDimension_,
@@ -128,7 +129,9 @@ function stypDimension<Unit extends string>(
     val: number,
     unit: Unit,
     opts: StypDimension_.Opts<Unit>): StypDimension_<Unit> | StypZero<Unit> {
-  return val ? new StypDimension<Unit>(val, unit, opts) : opts.dim.zero.prioritize(opts.priority || 0);
+  return val
+      ? new StypDimension<Unit>(val, unit, opts)
+      : opts.dim.zero.prioritize(opts.priority || StypPriority.Default);
 }
 
 /**

--- a/src/value/numeric/numeric.spec.ts
+++ b/src/value/numeric/numeric.spec.ts
@@ -1,4 +1,5 @@
 import { textAndPriority } from '../../spec';
+import { StypPriority } from '../priority';
 import { StypCalc, StypDimension } from './numeric';
 import { StypAddSub, StypMulDiv } from './numeric.impl';
 import { StypFrequency, StypLength, StypLengthPt, StypTime } from '../unit';
@@ -200,8 +201,10 @@ describe('StypCalc', () => {
 
   describe('add', () => {
     it('adds the value', () => {
-      expect(textAndPriority(calc.add(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) + 1rem)', 0]);
-      expect(textAndPriority(important.add(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) + 1rem)', 1]);
+      expect(textAndPriority(calc.add(StypLengthPt.of(1, 'rem'))))
+          .toEqual(['calc((12px + 100%) + 1rem)', StypPriority.Usual]);
+      expect(textAndPriority(important.add(StypLengthPt.of(1, 'rem'))))
+          .toEqual(['calc((12px + 100%) + 1rem)', StypPriority.Important]);
     });
     it('does not add zero value', () => {
       expect(calc.add(StypLengthPt.zero)).toBe(calc);
@@ -211,8 +214,10 @@ describe('StypCalc', () => {
 
   describe('sub', () => {
     it('subtracts the value', () => {
-      expect(textAndPriority(calc.sub(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) - 1rem)', 0]);
-      expect(textAndPriority(important.sub(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) - 1rem)', 1]);
+      expect(textAndPriority(calc.sub(StypLengthPt.of(1, 'rem'))))
+          .toEqual(['calc((12px + 100%) - 1rem)', StypPriority.Usual]);
+      expect(textAndPriority(important.sub(StypLengthPt.of(1, 'rem'))))
+          .toEqual(['calc((12px + 100%) - 1rem)', StypPriority.Important]);
     });
     it('does not subtract zero value', () => {
       expect(calc.sub(StypLengthPt.zero)).toBe(calc);
@@ -222,12 +227,16 @@ describe('StypCalc', () => {
 
   describe('mul', () => {
     it('multiplies', () => {
-      expect(textAndPriority(calc.mul(2))).toEqual(['calc((12px + 100%) * 2)', 0]);
-      expect(textAndPriority(important.mul(2))).toEqual(['calc((12px + 100%) * 2)', 1]);
+      expect(textAndPriority(calc.mul(2)))
+          .toEqual(['calc((12px + 100%) * 2)', StypPriority.Usual]);
+      expect(textAndPriority(important.mul(2)))
+          .toEqual(['calc((12px + 100%) * 2)', StypPriority.Important]);
     });
     it('multiplies the multiplier', () => {
-      expect(textAndPriority(calc.mul(2).mul(3))).toEqual(['calc((12px + 100%) * 6)', 0]);
-      expect(textAndPriority(important.mul(2).mul(3))).toEqual(['calc((12px + 100%) * 6)', 1]);
+      expect(textAndPriority(calc.mul(2).mul(3)))
+          .toEqual(['calc((12px + 100%) * 6)', StypPriority.Usual]);
+      expect(textAndPriority(important.mul(2).mul(3)))
+          .toEqual(['calc((12px + 100%) * 6)', StypPriority.Important]);
     });
     it('results to zero when multiplied by zero', () => {
       expect(calc.mul(0)).toBe(StypLengthPt.zero);
@@ -238,48 +247,64 @@ describe('StypCalc', () => {
       expect(important.mul(1)).toBe(important);
     });
     it('divides the divisor', () => {
-      expect(textAndPriority(calc.div(3).mul(2))).toEqual(['calc((12px + 100%) / 1.5)', 0]);
-      expect(textAndPriority(important.div(3).mul(2))).toEqual(['calc((12px + 100%) / 1.5)', 1]);
+      expect(textAndPriority(calc.div(3).mul(2)))
+          .toEqual(['calc((12px + 100%) / 1.5)', StypPriority.Usual]);
+      expect(textAndPriority(important.div(3).mul(2)))
+          .toEqual(['calc((12px + 100%) / 1.5)', StypPriority.Important]);
     });
   });
 
   describe('div', () => {
     it('divides', () => {
-      expect(textAndPriority(calc.div(2))).toEqual(['calc((12px + 100%) / 2)', 0]);
-      expect(textAndPriority(important.div(2))).toEqual(['calc((12px + 100%) / 2)', 1]);
+      expect(textAndPriority(calc.div(2)))
+          .toEqual(['calc((12px + 100%) / 2)', StypPriority.Usual]);
+      expect(textAndPriority(important.div(2)))
+          .toEqual(['calc((12px + 100%) / 2)', StypPriority.Important]);
     });
     it('multiplies the divisor', () => {
-      expect(textAndPriority(calc.div(2).div(3))).toEqual(['calc((12px + 100%) / 6)', 0]);
-      expect(textAndPriority(important.div(2).div(3))).toEqual(['calc((12px + 100%) / 6)', 1]);
+      expect(textAndPriority(calc.div(2).div(3)))
+          .toEqual(['calc((12px + 100%) / 6)', StypPriority.Usual]);
+      expect(textAndPriority(important.div(2).div(3)))
+          .toEqual(['calc((12px + 100%) / 6)', StypPriority.Important]);
     });
     it('results to the left operand when divided by one', () => {
       expect(calc.div(1)).toBe(calc);
       expect(important.div(1)).toBe(important);
     });
     it('divides the multiplier', () => {
-      expect(textAndPriority(calc.mul(3).div(2))).toEqual(['calc((12px + 100%) * 1.5)', 0]);
-      expect(textAndPriority(important.mul(3).div(2))).toEqual(['calc((12px + 100%) * 1.5)', 1]);
+      expect(textAndPriority(calc.mul(3).div(2)))
+          .toEqual(['calc((12px + 100%) * 1.5)', StypPriority.Usual]);
+      expect(textAndPriority(important.mul(3).div(2)))
+          .toEqual(['calc((12px + 100%) * 1.5)', StypPriority.Important]);
     });
   });
 
   describe('negate', () => {
     it('negates operands of the sum', () => {
-      expect(textAndPriority(calc.negate())).toEqual(['calc(-12px - 100%)', 0]);
-      expect(textAndPriority(important.negate())).toEqual(['calc(-12px - 100%)', 1]);
+      expect(textAndPriority(calc.negate()))
+          .toEqual(['calc(-12px - 100%)', StypPriority.Usual]);
+      expect(textAndPriority(important.negate()))
+          .toEqual(['calc(-12px - 100%)', StypPriority.Important]);
     });
     it('reverts operands of the diff', () => {
       calc = left.sub(right) as StypCalc<StypLengthPt.Unit>;
       important = calc.important();
-      expect(textAndPriority(calc.negate())).toEqual(['calc(100% - 12px)', 0]);
-      expect(textAndPriority(important.negate())).toEqual(['calc(100% - 12px)', 1]);
+      expect(textAndPriority(calc.negate()))
+          .toEqual(['calc(100% - 12px)', StypPriority.Usual]);
+      expect(textAndPriority(important.negate()))
+          .toEqual(['calc(100% - 12px)', StypPriority.Important]);
     });
     it('negates the multiplier', () => {
-      expect(textAndPriority(calc.mul(2).negate())).toEqual(['calc((12px + 100%) * -2)', 0]);
-      expect(textAndPriority(important.mul(2).negate())).toEqual(['calc((12px + 100%) * -2)', 1]);
+      expect(textAndPriority(calc.mul(2).negate()))
+          .toEqual(['calc((12px + 100%) * -2)', StypPriority.Usual]);
+      expect(textAndPriority(important.mul(2).negate()))
+          .toEqual(['calc((12px + 100%) * -2)', StypPriority.Important]);
     });
     it('negates the divisor', () => {
-      expect(textAndPriority(calc.div(2).negate())).toEqual(['calc((12px + 100%) / -2)', 0]);
-      expect(textAndPriority(important.div(2).negate())).toEqual(['calc((12px + 100%) / -2)', 1]);
+      expect(textAndPriority(calc.div(2).negate()))
+          .toEqual(['calc((12px + 100%) / -2)', StypPriority.Usual]);
+      expect(textAndPriority(important.div(2).negate()))
+          .toEqual(['calc((12px + 100%) / -2)', StypPriority.Important]);
     });
   });
 

--- a/src/value/numeric/numeric.spec.ts
+++ b/src/value/numeric/numeric.spec.ts
@@ -1,3 +1,4 @@
+import { textAndPriority } from '../../spec';
 import { StypCalc, StypDimension } from './numeric';
 import { StypAddSub, StypMulDiv } from './numeric.impl';
 import { StypFrequency, StypLength, StypLengthPt, StypTime } from '../unit';
@@ -147,9 +148,7 @@ describe('StypDimension', () => {
   describe('toString', () => {
     it('is `<value><unit>`', () => {
       expect(`${value}`).toBe('16px');
-    });
-    it('is `<value><unit> !important` is important', () => {
-      expect(`${value.important()}`).toBe('16px !important');
+      expect(`${value.important()}`).toBe('16px');
     });
   });
 });
@@ -201,8 +200,8 @@ describe('StypCalc', () => {
 
   describe('add', () => {
     it('adds the value', () => {
-      expect(`${calc.add(StypLengthPt.of(1, 'rem'))}`).toBe('calc((12px + 100%) + 1rem)');
-      expect(`${important.add(StypLengthPt.of(1, 'rem'))}`).toBe('calc((12px + 100%) + 1rem) !important');
+      expect(textAndPriority(calc.add(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) + 1rem)', 0]);
+      expect(textAndPriority(important.add(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) + 1rem)', 1]);
     });
     it('does not add zero value', () => {
       expect(calc.add(StypLengthPt.zero)).toBe(calc);
@@ -212,8 +211,8 @@ describe('StypCalc', () => {
 
   describe('sub', () => {
     it('subtracts the value', () => {
-      expect(`${calc.sub(StypLengthPt.of(1, 'rem'))}`).toBe('calc((12px + 100%) - 1rem)');
-      expect(`${important.sub(StypLengthPt.of(1, 'rem'))}`).toBe('calc((12px + 100%) - 1rem) !important');
+      expect(textAndPriority(calc.sub(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) - 1rem)', 0]);
+      expect(textAndPriority(important.sub(StypLengthPt.of(1, 'rem')))).toEqual(['calc((12px + 100%) - 1rem)', 1]);
     });
     it('does not subtract zero value', () => {
       expect(calc.sub(StypLengthPt.zero)).toBe(calc);
@@ -223,12 +222,12 @@ describe('StypCalc', () => {
 
   describe('mul', () => {
     it('multiplies', () => {
-      expect(`${calc.mul(2)}`).toBe('calc((12px + 100%) * 2)');
-      expect(`${important.mul(2)}`).toBe('calc((12px + 100%) * 2) !important');
+      expect(textAndPriority(calc.mul(2))).toEqual(['calc((12px + 100%) * 2)', 0]);
+      expect(textAndPriority(important.mul(2))).toEqual(['calc((12px + 100%) * 2)', 1]);
     });
     it('multiplies the multiplier', () => {
-      expect(`${calc.mul(2).mul(3)}`).toBe('calc((12px + 100%) * 6)');
-      expect(`${important.mul(2).mul(3)}`).toBe('calc((12px + 100%) * 6) !important');
+      expect(textAndPriority(calc.mul(2).mul(3))).toEqual(['calc((12px + 100%) * 6)', 0]);
+      expect(textAndPriority(important.mul(2).mul(3))).toEqual(['calc((12px + 100%) * 6)', 1]);
     });
     it('results to zero when multiplied by zero', () => {
       expect(calc.mul(0)).toBe(StypLengthPt.zero);
@@ -239,48 +238,48 @@ describe('StypCalc', () => {
       expect(important.mul(1)).toBe(important);
     });
     it('divides the divisor', () => {
-      expect(`${calc.div(3).mul(2)}`).toBe('calc((12px + 100%) / 1.5)');
-      expect(`${important.div(3).mul(2)}`).toBe('calc((12px + 100%) / 1.5) !important');
+      expect(textAndPriority(calc.div(3).mul(2))).toEqual(['calc((12px + 100%) / 1.5)', 0]);
+      expect(textAndPriority(important.div(3).mul(2))).toEqual(['calc((12px + 100%) / 1.5)', 1]);
     });
   });
 
   describe('div', () => {
     it('divides', () => {
-      expect(`${calc.div(2)}`).toBe('calc((12px + 100%) / 2)');
-      expect(`${important.div(2)}`).toBe('calc((12px + 100%) / 2) !important');
+      expect(textAndPriority(calc.div(2))).toEqual(['calc((12px + 100%) / 2)', 0]);
+      expect(textAndPriority(important.div(2))).toEqual(['calc((12px + 100%) / 2)', 1]);
     });
     it('multiplies the divisor', () => {
-      expect(`${calc.div(2).div(3)}`).toBe('calc((12px + 100%) / 6)');
-      expect(`${important.div(2).div(3)}`).toBe('calc((12px + 100%) / 6) !important');
+      expect(textAndPriority(calc.div(2).div(3))).toEqual(['calc((12px + 100%) / 6)', 0]);
+      expect(textAndPriority(important.div(2).div(3))).toEqual(['calc((12px + 100%) / 6)', 1]);
     });
     it('results to the left operand when divided by one', () => {
       expect(calc.div(1)).toBe(calc);
       expect(important.div(1)).toBe(important);
     });
     it('divides the multiplier', () => {
-      expect(`${calc.mul(3).div(2)}`).toBe('calc((12px + 100%) * 1.5)');
-      expect(`${important.mul(3).div(2)}`).toBe('calc((12px + 100%) * 1.5) !important');
+      expect(textAndPriority(calc.mul(3).div(2))).toEqual(['calc((12px + 100%) * 1.5)', 0]);
+      expect(textAndPriority(important.mul(3).div(2))).toEqual(['calc((12px + 100%) * 1.5)', 1]);
     });
   });
 
   describe('negate', () => {
     it('negates operands of the sum', () => {
-      expect(`${calc.negate()}`).toBe('calc(-12px - 100%)');
-      expect(`${important.negate()}`).toBe('calc(-12px - 100%) !important');
+      expect(textAndPriority(calc.negate())).toEqual(['calc(-12px - 100%)', 0]);
+      expect(textAndPriority(important.negate())).toEqual(['calc(-12px - 100%)', 1]);
     });
     it('reverts operands of the diff', () => {
       calc = left.sub(right) as StypCalc<StypLengthPt.Unit>;
       important = calc.important();
-      expect(`${calc.negate()}`).toBe('calc(100% - 12px)');
-      expect(`${important.negate()}`).toBe('calc(100% - 12px) !important');
+      expect(textAndPriority(calc.negate())).toEqual(['calc(100% - 12px)', 0]);
+      expect(textAndPriority(important.negate())).toEqual(['calc(100% - 12px)', 1]);
     });
     it('negates the multiplier', () => {
-      expect(`${calc.mul(2).negate()}`).toBe('calc((12px + 100%) * -2)');
-      expect(`${important.mul(2).negate()}`).toBe('calc((12px + 100%) * -2) !important');
+      expect(textAndPriority(calc.mul(2).negate())).toEqual(['calc((12px + 100%) * -2)', 0]);
+      expect(textAndPriority(important.mul(2).negate())).toEqual(['calc((12px + 100%) * -2)', 1]);
     });
     it('negates the divisor', () => {
-      expect(`${calc.div(2).negate()}`).toBe('calc((12px + 100%) / -2)');
-      expect(`${important.div(2).negate()}`).toBe('calc((12px + 100%) / -2) !important');
+      expect(textAndPriority(calc.div(2).negate())).toEqual(['calc((12px + 100%) / -2)', 0]);
+      expect(textAndPriority(important.div(2).negate())).toEqual(['calc((12px + 100%) / -2)', 1]);
     });
   });
 
@@ -294,7 +293,7 @@ describe('StypCalc', () => {
   describe('toString', () => {
     it('is calc() function call', () => {
       expect(`${calc}`).toBe('calc(12px + 100%)');
-      expect(`${important}`).toBe('calc(12px + 100%) !important');
+      expect(`${important}`).toBe('calc(12px + 100%)');
     });
   });
 });

--- a/src/value/numeric/numeric.ts
+++ b/src/value/numeric/numeric.ts
@@ -68,10 +68,7 @@ export abstract class StypNumericStruct<Self extends StypNumericStruct<Self, Uni
   abstract toFormula(): string;
 
   toString() {
-
-    const string = this.toFormula();
-
-    return this.priority ? string + ' !important' : string;
+    return this.toFormula();
   }
 
 }

--- a/src/value/numeric/zero.impl.ts
+++ b/src/value/numeric/zero.impl.ts
@@ -1,5 +1,5 @@
-import { StypDimension, StypNumeric, StypNumericStruct } from './';
 import { StypValue } from '../value';
+import { StypDimension, StypNumeric, StypNumericStruct } from './';
 import { StypZero } from './zero';
 
 class Zero<Unit extends string> extends StypNumericStruct<Zero<Unit>, Unit> implements StypZero<Unit> {
@@ -27,7 +27,7 @@ class Zero<Unit extends string> extends StypNumericStruct<Zero<Unit>, Unit> impl
       return !this.priority;
     }
     if (other === '0 !important') {
-      return this.priority === 'important';
+      return this.priority === 1;
     }
     return false;
   }
@@ -52,7 +52,7 @@ class Zero<Unit extends string> extends StypNumericStruct<Zero<Unit>, Unit> impl
     return this;
   }
 
-  prioritize(priority: 'important' | undefined): Zero<Unit> {
+  prioritize(priority: number): Zero<Unit> {
     return this._byPriority.get(priority);
   }
 
@@ -68,10 +68,6 @@ class Zero<Unit extends string> extends StypNumericStruct<Zero<Unit>, Unit> impl
     return '0';
   }
 
-  toString(): string {
-    return this.priority ? '0 !important' : '0';
-  }
-
 }
 
 class ZeroByPriority<Unit extends string> {
@@ -79,13 +75,17 @@ class ZeroByPriority<Unit extends string> {
   readonly usual: Zero<Unit>;
   readonly important: Zero<Unit>;
 
-  constructor(dim: StypDimension.Kind<Unit>) {
+  constructor(readonly dim: StypDimension.Kind<Unit>) {
     this.usual = new Zero(this, { dim });
-    this.important = new Zero(this, { dim, priority: 'important' });
+    this.important = new Zero(this, { dim, priority: 1 });
   }
 
-  get(priority: 'important' | undefined): Zero<Unit> {
-    return priority ? this.important : this.usual;
+  get(priority: number): Zero<Unit> {
+    switch (priority) {
+      case 0: return this.usual;
+      case 1: return this.important;
+    }
+    return new Zero(this, { dim: this.dim, priority });
   }
 
 }

--- a/src/value/numeric/zero.impl.ts
+++ b/src/value/numeric/zero.impl.ts
@@ -1,3 +1,4 @@
+import { StypPriority } from '../priority';
 import { StypValue } from '../value';
 import { StypDimension, StypNumeric, StypNumericStruct } from './';
 import { StypZero } from './zero';
@@ -24,10 +25,10 @@ class Zero<Unit extends string> extends StypNumericStruct<Zero<Unit>, Unit> impl
       return other.type === this.type && other.priority === this.priority;
     }
     if (other === 0 || other === '0') {
-      return !this.priority;
+      return this.priority === StypPriority.Usual;
     }
     if (other === '0 !important') {
-      return this.priority === 1;
+      return this.priority === StypPriority.Important;
     }
     return false;
   }
@@ -77,13 +78,13 @@ class ZeroByPriority<Unit extends string> {
 
   constructor(readonly dim: StypDimension.Kind<Unit>) {
     this.usual = new Zero(this, { dim });
-    this.important = new Zero(this, { dim, priority: 1 });
+    this.important = new Zero(this, { dim, priority: StypPriority.Important });
   }
 
   get(priority: number): Zero<Unit> {
     switch (priority) {
-      case 0: return this.usual;
-      case 1: return this.important;
+      case StypPriority.Usual: return this.usual;
+      case StypPriority.Important: return this.important;
     }
     return new Zero(this, { dim: this.dim, priority });
   }

--- a/src/value/numeric/zero.spec.ts
+++ b/src/value/numeric/zero.spec.ts
@@ -1,5 +1,4 @@
-import { StypLength, StypLengthPt, StypResolution } from '../unit';
-import { StypTime } from '../unit/time';
+import { StypLength, StypLengthPt, StypResolution, StypTime } from '../unit';
 import { stypValuesEqual } from '../value';
 import { StypZero } from './zero';
 
@@ -117,11 +116,20 @@ describe('StypZero', () => {
     });
   });
 
+  describe('prioritize', () => {
+    it('assigns priority', () => {
+
+      const prioritized = zero.prioritize(2);
+
+      expect(prioritized.priority).toBe(2);
+    });
+  });
+
   describe('important', () => {
     it('is singleton', () => {
       expect(zero.important()).toBe(important);
       expect(important.important()).toBe(important);
-      expect(zero.prioritize('important')).toBe(important);
+      expect(zero.prioritize(1)).toBe(important);
     });
   });
 
@@ -129,7 +137,7 @@ describe('StypZero', () => {
     it('is singleton', () => {
       expect(zero.usual()).toBe(zero);
       expect(important.usual()).toBe(zero);
-      expect(zero.prioritize(undefined)).toBe(zero);
+      expect(zero.prioritize(0)).toBe(zero);
     });
   });
 
@@ -143,9 +151,7 @@ describe('StypZero', () => {
   describe('toString', () => {
     it('is `0`', () => {
       expect(`${zero}`).toBe('0');
-    });
-    it('is `0 !important` if important', () => {
-      expect(`${important}`).toBe('0 !important');
+      expect(`${important}`).toBe('0');
     });
   });
 });

--- a/src/value/priority.spec.ts
+++ b/src/value/priority.spec.ts
@@ -1,0 +1,48 @@
+import { stypSplitPriority } from './priority';
+import { StypLength } from './unit';
+import { StypValue } from './value';
+
+describe('stypSplitPriority', () => {
+  it('splits nothing when there is no value', () => {
+
+    const result: [undefined, 0] = stypSplitPriority(undefined);
+
+    expect(result).toEqual([undefined, 0]);
+  });
+  it('splits string value and priority', () => {
+
+    const result1: [string, 0 | 1] = stypSplitPriority('1px !important');
+
+    expect(result1).toEqual(['1px', 1]);
+
+    const result2 = stypSplitPriority('1px');
+
+    expect(result2).toEqual(['1px', 0]);
+  });
+  it('does not extract priority from scalar value', () => {
+
+    const result: [number, 0] = stypSplitPriority(1);
+
+    expect(result).toEqual([1, 0]);
+  });
+  it('splits structures value and priority', () => {
+
+    const value = StypLength.of(1, 'px');
+
+    const result1: [StypLength, number] = stypSplitPriority(value.important());
+
+    expect(valueTextAndPriority(result1)).toEqual([`${value}`, 1]);
+
+    const result2: [StypLength, number] = stypSplitPriority(value);
+
+    expect(valueTextAndPriority(result2)).toEqual([`${value}`, 0]);
+
+    const result3: [StypLength, number] = stypSplitPriority(value.prioritize(0.5));
+
+    expect(valueTextAndPriority(result3)).toEqual([`${value}`, 0.5]);
+  });
+});
+
+function valueTextAndPriority([value, priority]: [StypValue, number]): [string, number] {
+  return [`${value}`, priority];
+}

--- a/src/value/priority.ts
+++ b/src/value/priority.ts
@@ -1,0 +1,86 @@
+import { IMPORTANT_CSS_SUFFIX } from '../internal';
+import { StypValue } from './value';
+
+/**
+ * Predefined CSS property value priorities.
+ */
+export const enum StypPriority {
+
+  /**
+   * Usual, non-important priority.
+   *
+   * This priority is assigned to values by `StypValueStruct.usual()` method.
+   */
+  Usual = 0,
+
+  /**
+   * Default priority.
+   *
+   * The same as `Usual`. This priority is assigned to values by default.
+   */
+  Default = Usual,
+
+  /**
+   * Important priority.
+   *
+   * This priority corresponds to values with `!important` suffix. It is applied to string values with `!important`
+   * suffix, and can be assigned to structured values using `StypValueStruct.important()` method.
+   *
+   * All numeric priorities with higher values are rendered as `!important` ones.
+   */
+  Important = 1,
+
+}
+
+/**
+ * Splits undefined CSS property value onto non-prioritized value and priority.
+ *
+ * @param value Undefined CSS property value to split.
+ *
+ * @returns An `[undefined, 0]` tuple.
+ */
+export function stypSplitPriority<T extends StypValue>(value: undefined): [undefined, 0];
+
+/**
+ * Splits string CSS property value onto non-prioritized value and priority.
+ *
+ * @param value CSS property value to split.
+ *
+ * @returns A tuple containing the value without `!priority` suffix, and numeric priority (0 or 1).
+ */
+export function stypSplitPriority(value: string): [string, 0 | 1];
+
+/**
+ * Splits scalar CSS property value onto non-prioritized value and priority.
+ *
+ * @param value CSS property value to split.
+ *
+ * @returns A tuple containing the value and `0` priority.
+ */
+export function stypSplitPriority<T extends number | boolean>(value: T): [T, 0];
+
+/**
+ * Splits arbitrary CSS property value onto value non-prioritized value and priority.
+ *
+ * @param value CSS property value to split.
+ *
+ * @returns A tuple containing the value and numeric priority.
+ */
+export function stypSplitPriority<T extends StypValue>(value: T): [T, number];
+
+export function stypSplitPriority<T extends StypValue>(value: T): [T, number] {
+  if (value == null) {
+    return [undefined as T, StypPriority.Default];
+  }
+
+  switch (typeof value) {
+    case 'object':
+      return [value, value.priority];
+    case 'string':
+      if (value.endsWith(IMPORTANT_CSS_SUFFIX)) {
+        return[value.substring(0, value.length - IMPORTANT_CSS_SUFFIX.length).trim() as T, StypPriority.Important];
+      }
+  }
+
+  return [value, StypPriority.Default];
+}

--- a/src/value/url.spec.ts
+++ b/src/value/url.spec.ts
@@ -20,7 +20,7 @@ describe('StypURL', () => {
       const important = value.important();
 
       expect(important).not.toBe(value);
-      expect(important.priority).toBe('important');
+      expect(important.priority).toBe(1);
       expect(important.url).toBe(value.url);
       expect(important).toEqual(value.important());
     });

--- a/src/value/url.spec.ts
+++ b/src/value/url.spec.ts
@@ -1,3 +1,4 @@
+import { StypPriority } from './priority';
 import { StypLength } from './unit';
 import { StypURL } from './url';
 
@@ -20,7 +21,7 @@ describe('StypURL', () => {
       const important = value.important();
 
       expect(important).not.toBe(value);
-      expect(important.priority).toBe(1);
+      expect(important.priority).toBe(StypPriority.Important);
       expect(important.url).toBe(value.url);
       expect(important).toEqual(value.important());
     });

--- a/src/value/url.ts
+++ b/src/value/url.ts
@@ -1,5 +1,6 @@
 import cssesc from 'cssesc';
-import { stypSplitPriority, StypValue, StypValueStruct } from './value';
+import { stypSplitPriority } from './priority';
+import { StypValue, StypValueStruct } from './value';
 
 /**
  * Structured [<url>] CSS property value.
@@ -36,9 +37,9 @@ export class StypURL extends StypValueStruct<StypURL> {
     switch (typeof source) {
       case 'string':
 
-        const [value, priority] = stypSplitPriority(source);
+        const [url, priority] = stypSplitPriority(source);
 
-        return new StypURL(value, { priority });
+        return new StypURL(url, { priority });
       case 'object':
         if (source.type === 'url') {
           return source;

--- a/src/value/url.ts
+++ b/src/value/url.ts
@@ -62,7 +62,7 @@ export class StypURL extends StypValueStruct<StypURL> {
     return StypURL.by(source) || this;
   }
 
-  prioritize(priority: 'important' | undefined): StypURL {
+  prioritize(priority: number): StypURL {
     return priority === this.priority ? this : new StypURL(this.url, { priority });
   }
 

--- a/src/value/value.spec.ts
+++ b/src/value/value.spec.ts
@@ -1,40 +1,44 @@
 import { StypLength } from './unit';
-import { stypSplitPriority, stypValuesEqual } from './value';
+import { stypSplitPriority, StypValue, stypValuesEqual } from './value';
 
 describe('stypSplitPriority', () => {
   it('splits nothing when there is no value', () => {
 
-    const result: [] = stypSplitPriority(undefined);
+    const result: [undefined, 0] = stypSplitPriority(undefined);
 
-    expect(result).toEqual([]);
+    expect(result).toEqual([undefined, 0]);
   });
   it('splits string value and priority', () => {
 
-    const result1: [string, 'important'?] = stypSplitPriority('1px !important');
+    const result1: [string, 0 | 1] = stypSplitPriority('1px !important');
 
-    expect(result1).toEqual(['1px', 'important']);
+    expect(result1).toEqual(['1px', 1]);
 
     const result2 = stypSplitPriority('1px');
 
-    expect(result2).toEqual(['1px']);
+    expect(result2).toEqual(['1px', 0]);
   });
   it('does not extract priority from scalar value', () => {
 
-    const result: [number] = stypSplitPriority(1);
+    const result: [number, 0] = stypSplitPriority(1);
 
-    expect(result).toEqual([1]);
+    expect(result).toEqual([1, 0]);
   });
   it('splits structures value and priority', () => {
 
     const value = StypLength.of(1, 'px');
 
-    const result1: [StypLength, 'important'?] = stypSplitPriority(value.important());
+    const result1: [StypLength, number] = stypSplitPriority(value.important());
 
-    expect(result1).toEqual([value, 'important']);
+    expect(valueTextAndPriority(result1)).toEqual([`${value}`, 1]);
 
-    const result2: [StypLength, 'important'?] = stypSplitPriority(value);
+    const result2: [StypLength, number] = stypSplitPriority(value);
 
-    expect(result2).toEqual([value]);
+    expect(valueTextAndPriority(result2)).toEqual([`${value}`, 0]);
+
+    const result3: [StypLength, number] = stypSplitPriority(value.prioritize(0.5));
+
+    expect(valueTextAndPriority(result3)).toEqual([`${value}`, 0.5]);
   });
 });
 
@@ -64,3 +68,7 @@ describe('stypValuesEqual', () => {
     expect(stypValuesEqual('0 !important', StypLength.zero.important())).toBe(true);
   });
 });
+
+function valueTextAndPriority([value, priority]: [StypValue, number]): [string, number] {
+  return [`${value}`, priority];
+}

--- a/src/value/value.spec.ts
+++ b/src/value/value.spec.ts
@@ -1,46 +1,5 @@
 import { StypLength } from './unit';
-import { stypSplitPriority, StypValue, stypValuesEqual } from './value';
-
-describe('stypSplitPriority', () => {
-  it('splits nothing when there is no value', () => {
-
-    const result: [undefined, 0] = stypSplitPriority(undefined);
-
-    expect(result).toEqual([undefined, 0]);
-  });
-  it('splits string value and priority', () => {
-
-    const result1: [string, 0 | 1] = stypSplitPriority('1px !important');
-
-    expect(result1).toEqual(['1px', 1]);
-
-    const result2 = stypSplitPriority('1px');
-
-    expect(result2).toEqual(['1px', 0]);
-  });
-  it('does not extract priority from scalar value', () => {
-
-    const result: [number, 0] = stypSplitPriority(1);
-
-    expect(result).toEqual([1, 0]);
-  });
-  it('splits structures value and priority', () => {
-
-    const value = StypLength.of(1, 'px');
-
-    const result1: [StypLength, number] = stypSplitPriority(value.important());
-
-    expect(valueTextAndPriority(result1)).toEqual([`${value}`, 1]);
-
-    const result2: [StypLength, number] = stypSplitPriority(value);
-
-    expect(valueTextAndPriority(result2)).toEqual([`${value}`, 0]);
-
-    const result3: [StypLength, number] = stypSplitPriority(value.prioritize(0.5));
-
-    expect(valueTextAndPriority(result3)).toEqual([`${value}`, 0.5]);
-  });
-});
+import { stypValuesEqual } from './value';
 
 describe('stypValuesEqual', () => {
   it('compares scalar values', () => {
@@ -68,7 +27,3 @@ describe('stypValuesEqual', () => {
     expect(stypValuesEqual('0 !important', StypLength.zero.important())).toBe(true);
   });
 });
-
-function valueTextAndPriority([value, priority]: [StypValue, number]): [string, number] {
-  return [`${value}`, priority];
-}

--- a/src/value/value.ts
+++ b/src/value/value.ts
@@ -1,6 +1,6 @@
-import { IMPORTANT_CSS_SUFFIX } from '../internal';
 import { StypColor } from './color';
 import { StypNumeric } from './numeric';
+import { StypPriority } from './priority';
 import { StypURL } from './url';
 
 /**
@@ -39,7 +39,7 @@ export abstract class StypValueStruct<Self extends StypValueStruct<Self>> {
    * @param opts Construction options.
    */
   protected constructor(opts?: StypValue.Opts) {
-    this.priority = opts && opts.priority || 0;
+    this.priority = opts && opts.priority || StypPriority.Default;
   }
 
   /**
@@ -65,7 +65,7 @@ export abstract class StypValueStruct<Self extends StypValueStruct<Self>> {
    * @returns Either a new value equal to this one but having `priority` equal to `1`, or this one if already the case.
    */
   important(): Self {
-    return this.prioritize(1);
+    return this.prioritize(StypPriority.Important);
   }
 
   /**
@@ -74,7 +74,7 @@ export abstract class StypValueStruct<Self extends StypValueStruct<Self>> {
    * @returns Either a new value equal to this one but having `priority` equal to `0`, or this one if already the case.
    */
   usual(): Self {
-    return this.prioritize(0);
+    return this.prioritize(StypPriority.Usual);
   }
 
   /**
@@ -116,59 +116,6 @@ export namespace StypValue {
 
   }
 
-}
-
-/**
- * Splits undefined CSS property value onto non-prioritized value and priority.
- *
- * @param value Undefined CSS property value to split.
- *
- * @returns An `[undefined, 0]` tuple.
- */
-export function stypSplitPriority<T extends StypValue>(value: undefined): [undefined, 0];
-
-/**
- * Splits string CSS property value onto non-prioritized value and priority.
- *
- * @param value CSS property value to split.
- *
- * @returns A tuple containing the value without `!priority` suffix, and numeric priority (0 or 1).
- */
-export function stypSplitPriority(value: string): [string, 0 | 1];
-
-/**
- * Splits scalar CSS property value onto non-prioritized value and priority.
- *
- * @param value CSS property value to split.
- *
- * @returns A tuple containing the value and `0` priority.
- */
-export function stypSplitPriority<T extends number | boolean>(value: T): [T, 0];
-
-/**
- * Splits arbitrary CSS property value onto value non-prioritized value and priority.
- *
- * @param value CSS property value to split.
- *
- * @returns A tuple containing the value and numeric priority.
- */
-export function stypSplitPriority<T extends StypValue>(value: T): [T, number];
-
-export function stypSplitPriority<T extends StypValue>(value: T): [T, number] {
-  if (value == null) {
-    return [undefined as T, 0];
-  }
-
-  switch (typeof value) {
-    case 'object':
-      return [value, value.priority];
-    case 'string':
-      if (value.endsWith(IMPORTANT_CSS_SUFFIX)) {
-        return[value.substring(0, value.length - IMPORTANT_CSS_SUFFIX.length).trim() as T, 1];
-      }
-  }
-
-  return [value, 0];
 }
 
 /**

--- a/src/value/value.ts
+++ b/src/value/value.ts
@@ -26,9 +26,12 @@ export type StypValue =
 export abstract class StypValueStruct<Self extends StypValueStruct<Self>> {
 
   /**
-   * CSS property value priority. E.g. whether it is `!important`.
+   * CSS property value priority.
+   *
+   * The value `StypPriority.Important` and above means the property is `!important`. Everything else means normal
+   * priority.
    */
-  readonly priority: 'important' | undefined;
+  readonly priority: number;
 
   /**
    * Constructs structured CSS property value.
@@ -36,7 +39,7 @@ export abstract class StypValueStruct<Self extends StypValueStruct<Self>> {
    * @param opts Construction options.
    */
   protected constructor(opts?: StypValue.Opts) {
-    this.priority = opts && opts.priority;
+    this.priority = opts && opts.priority || 0;
   }
 
   /**
@@ -54,24 +57,24 @@ export abstract class StypValueStruct<Self extends StypValueStruct<Self>> {
    * @returns Either a new value equal to this one but having the given `priority`, or this one if `priority` did
    * not change.
    */
-  abstract prioritize(priority: 'important' | undefined): Self;
+  abstract prioritize(priority: number): Self;
 
   /**
    * Creates `!important` variant of this value.
    *
-   * @returns Either a new value equal to this one but having `important` priority, or this one if already the case.
+   * @returns Either a new value equal to this one but having `priority` equal to `1`, or this one if already the case.
    */
   important(): Self {
-    return this.prioritize('important');
+    return this.prioritize(1);
   }
 
   /**
    * Creates usual (not `!important`) variant of this value.
    *
-   * @returns Either a new value equal to this one but having `undefined` priority, or this one if already the case.
+   * @returns Either a new value equal to this one but having `priority` equal to `0`, or this one if already the case.
    */
   usual(): Self {
-    return this.prioritize(undefined);
+    return this.prioritize(0);
   }
 
   /**
@@ -89,6 +92,8 @@ export abstract class StypValueStruct<Self extends StypValueStruct<Self>> {
   /**
    * Returns textual representation of this value.
    *
+   * Textual representation never contains an `!important` suffix.
+   *
    * @returns A textual representation of this value to use as CSS property value.
    */
   abstract toString(): string;
@@ -104,8 +109,10 @@ export namespace StypValue {
 
     /**
      * Constructed value priority.
+     *
+     * The value `1` and above means the property is `!important`. Everything else means normal priority.
      */
-    readonly priority?: 'important';
+    readonly priority?: number;
 
   }
 
@@ -116,64 +123,52 @@ export namespace StypValue {
  *
  * @param value Undefined CSS property value to split.
  *
- * @returns An empty tuple.
+ * @returns An `[undefined, 0]` tuple.
  */
-export function stypSplitPriority<T extends StypValue>(value: undefined): [];
+export function stypSplitPriority<T extends StypValue>(value: undefined): [undefined, 0];
 
 /**
  * Splits string CSS property value onto non-prioritized value and priority.
  *
  * @param value CSS property value to split.
  *
- * @returns A tuple containing the value without `!priority` suffix, and priority.
+ * @returns A tuple containing the value without `!priority` suffix, and numeric priority (0 or 1).
  */
-export function stypSplitPriority(value: string): [string, 'important'?];
+export function stypSplitPriority(value: string): [string, 0 | 1];
 
 /**
  * Splits scalar CSS property value onto non-prioritized value and priority.
  *
  * @param value CSS property value to split.
  *
- * @returns A tuple containing the value. Scalar value priority is always normal.
+ * @returns A tuple containing the value and `0` priority.
  */
-export function stypSplitPriority<T extends number | boolean>(value: T): [T];
-
-/**
- * Splits defined CSS property value onto non-prioritized value and priority.
- *
- * @param value CSS property value to split.
- *
- * @returns A tuple containing the value and priority.
- */
-export function stypSplitPriority<T extends StypValue>(value: Exclude<T, undefined>): [T, 'important'?];
+export function stypSplitPriority<T extends number | boolean>(value: T): [T, 0];
 
 /**
  * Splits arbitrary CSS property value onto value non-prioritized value and priority.
  *
  * @param value CSS property value to split.
  *
- * @returns A tuple containing the value and priority. Empty tuple if the value is `undefined`.
+ * @returns A tuple containing the value and numeric priority.
  */
-export function stypSplitPriority<T extends StypValue>(value: T): [T?, 'important'?];
+export function stypSplitPriority<T extends StypValue>(value: T): [T, number];
 
-export function stypSplitPriority<T extends StypValue>(value: T): [T?, 'important'?] {
+export function stypSplitPriority<T extends StypValue>(value: T): [T, number] {
   if (value == null) {
-    return [];
+    return [undefined as T, 0];
   }
 
   switch (typeof value) {
     case 'object':
-
-      const priority = value.priority;
-
-      return priority ? [value.usual() as T, priority] : [value];
+      return [value, value.priority];
     case 'string':
       if (value.endsWith(IMPORTANT_CSS_SUFFIX)) {
-        return[value.substring(0, value.length - IMPORTANT_CSS_SUFFIX.length).trim() as T, 'important'];
+        return[value.substring(0, value.length - IMPORTANT_CSS_SUFFIX.length).trim() as T, 1];
       }
   }
 
-  return [value];
+  return [value, 0];
 }
 
 /**


### PR DESCRIPTION
- `1` and above corresponds to `!important`
- `0` is default (usual) priority
- Add `StypPriority` enum with predefined priority values